### PR TITLE
Update link to fork in content warning

### DIFF
--- a/docs/.vuepress/components/ContentWarning.vue
+++ b/docs/.vuepress/components/ContentWarning.vue
@@ -4,9 +4,9 @@
     <p class="custom-block-title">This content is likely out of date</p>
     <p>
       The content of this course was written in May 2020, so parts will be outdated.
-      As of 2024, a maintained fork of the course is available at
-      <a href="https://learn-eleventy.pages.dev/"
-        >learn-eleventy.pages.dev</a
+      As of 2026, a maintained fork of the course is available at
+      <a href="https://learneleventy.dev/"
+        >learneleventy.dev</a
       > and new students are encouraged to use that version.
     </p>
     <p>


### PR DESCRIPTION
Updates the domain to the new one we've got for it, https://learneleventy.dev. Also updates the year since (I hope!) it is still a good resource two years later.